### PR TITLE
Fix on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,13 @@ dependency-reduced-pom.xml
 
 
 #################
+## IntelliJ
+#################
+*.iml
+.idea/
+
+
+#################
 ## Visual Studio
 #################
 

--- a/src/main/java/com/toddfast/mutagen/cassandra/impl/CassandraPlanner.java
+++ b/src/main/java/com/toddfast/mutagen/cassandra/impl/CassandraPlanner.java
@@ -9,6 +9,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import com.google.common.base.Joiner;
 import com.toddfast.mutagen.cassandra.utils.MutagenUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -165,8 +166,8 @@ public class CassandraPlanner extends BasicPlanner<String> {
 
         assert resource.endsWith(".class") : "Class resource name \"" + resource + "\" should end with .class";
 
-        int index = resource.indexOf(".class");
-        String className = resource.substring(0, index).replace('/', '.');
+        int index = resource.lastIndexOf(".class");
+        String className = Joiner.on('.').join(Paths.get(resource.substring(0, index)));
 
         // Load the class specified by the resource
         Class<?> clazz;

--- a/src/main/java/com/toddfast/mutagen/cassandra/utils/LoadResources.java
+++ b/src/main/java/com/toddfast/mutagen/cassandra/utils/LoadResources.java
@@ -2,6 +2,8 @@ package com.toddfast.mutagen.cassandra.utils;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -110,7 +112,7 @@ public class LoadResources {
 
                 if (resource.endsWith(".class") || resource.endsWith(".java")) {
                     // Remove the file path
-                    resource = resource.substring(resource.indexOf(rootResourcePath));
+                    resource = relativize(resource, rootResourcePath);
                     if (resource.contains("$")) {
                         // skip inner classes
                         continue;
@@ -123,5 +125,23 @@ public class LoadResources {
                     "path \"" + rootResourcePath + "\"", e);
         }
         return resources;
+    }
+
+    /**
+     * Returns a new path that points to the same location as the first parameter, but starts with the second parameter.
+     * If the second parameter is not contained in the first, returns an empty string.
+     *
+     * This is equivalent to pathToRelativize.substring(pathToRelativize.indexOf(root)), except
+     * that it will correctly handle the case where the two paths don't use the same separator.
+     *
+     * Example: x/y/z/a/b/c/d/e, a/b/c -> a/b/c/d/e
+     */
+    private static String relativize(String pathToRelativize, String root) {
+        Path rootPath = Paths.get(root);
+        Path result = Paths.get(pathToRelativize);
+        while (result.getNameCount() > 1 && !result.startsWith(rootPath)) {
+            result = result.subpath(1, result.getNameCount());
+        }
+        return result.toString();
     }
 }


### PR DESCRIPTION
The code makes the assumptions that all paths use the slash as a separator. This doesn't work because the `ResourceScanner` can return paths coming from the file system, which on Windows use anti-slashes.

This is a quick and dirty patch to work around the problem. This is not ideal. This is a hack.

The proper way to fix this would be to patch the `ResourceScanner` from the mutagen project ([issue](https://github.com/toddfast/mutagen-cassandra/issues/5)). However, to avoid the cost of having to fork that project too, we will settle with this hack.

- [x] All tests pass
- [x] All tests of com.apispark.db pass
- [x] Can reset db using com.apispark.db from Eclipse
- [x] Can reset db using com.apispark.db from JAR